### PR TITLE
Moves PHPUnit dependency from require-dev to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "require": {
         "php": ">=5.4",
         "behat/behat": "~3.0",
-        "guzzlehttp/guzzle": "4.*"
+        "guzzlehttp/guzzle": "4.*",
+        "phpunit/phpunit": "~4.0"
     },
 
     "require-dev": {
         "symfony/process": "~2.1",
-        "silex/silex": "~1",
-        "phpunit/phpunit": "~4.0"
+        "silex/silex": "~1"
     },
 
     "autoload": {


### PR DESCRIPTION
Since the main context (`WebApiContext`) depends on PHPUnit assertion functions, the PHPUnit dependency must be moved form dev-dependency to regular one.

(I didn't see the issue before but I'm currently working on a project which use phpspec only and I was unable to use this context without installing PHPUnit).
