### PR TITLE
Uses header name key based array for header assignation in Guzzle 4 requests

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -353,10 +353,8 @@ class WebApiContext implements ApiClientAwareContext
      */
     protected function removeHeader($headerName)
     {
-        foreach ($this->headers as $headerIndex => $headerValue) {
-            if (strpos($headerValue, $headerName) === 0) {
-                unset($this->headers[$headerIndex]);
-            }
+        if (array_key_exists($headerName, $this->headers)) {
+            unset($this->headers[$headerName]);
         }
     }
 


### PR DESCRIPTION
In Guzzle 4, the `$request->addHeaders($headers)` method expects to receive an associative array indexed by header names.

The headers array can contains scalar values or sub-arrays.

This PR fixes the `WebApiContext` context to be Guzzle 4 compatible.

Note: The tests passed before since the assertion is based only on the presence of the header name/value in the response body, but the sent headers where not formatted correctly.

This is the previous output from the test application embed with the extension for testing purpose:

``` json
{
    "warning":"Do not expose this service in production : it is intrinsically unsafe",
    "method":"GET",
    "headers": {
        "host":["localhost:8080"],
        "user-agent":["Guzzle\/4.0.2 curl\/7.21.4 PHP\/5.5.6"],
        "0":["foobar:bazquux"]
    }
}
```

After:

``` json
{
    "warning":"Do not expose this service in production : it is intrinsically unsafe",
    "method":"GET",
    "headers": {
        "host":["localhost:8080"],
        "user-agent":["Guzzle\/4.0.2 curl\/7.21.4 PHP\/5.5.6"],
        "foobar":["bazquux"]
    }
}
```
