### PR TITLE
check first if request and response are indeed objects

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -266,9 +266,11 @@ class WebApiContext implements ApiClientAwareContext
         $request = $this->request;
         $response = $this->response;
 
-	    if ($request == null || $response == null) return;
+        if ($request == null || $response == null) {
+            return;
+        }
 
-	    echo sprintf(
+        echo sprintf(
             "%s %s => %d:\n%s",
             $request->getMethod(),
             $request->getUrl(),

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -266,7 +266,9 @@ class WebApiContext implements ApiClientAwareContext
         $request = $this->request;
         $response = $this->response;
 
-        echo sprintf(
+	    if ($request == null || $response == null) return;
+
+	    echo sprintf(
             "%s %s => %d:\n%s",
             $request->getMethod(),
             $request->getUrl(),


### PR DESCRIPTION
fixes race condition

since i use printResponse as a AfterScenario hook information why a call was not working:

```
    /**
     * catch and show errors
     *
     * @param AfterScenarioScope $scope
     *
     * @AfterScenario
     */
    public function catchErrors(AfterScenarioScope $scope)
    {
        if ($scope->getTestResult()->isPassed()) {
            return;
        }

        $this->printResponse();
    }
```
