### PR TITLE
Add stuff to use JsonContext

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -103,6 +103,8 @@ class WebApiContext implements ApiClientAwareContext
         }
 
         $this->sendRequest();
+
+        return $this->response;
     }
 
     /**
@@ -132,6 +134,8 @@ class WebApiContext implements ApiClientAwareContext
         }
 
         $this->sendRequest();
+
+        return $this->response;
     }
 
     /**
@@ -157,6 +161,8 @@ class WebApiContext implements ApiClientAwareContext
             )
         );
         $this->sendRequest();
+
+        return $this->response;
     }
 
     /**
@@ -183,6 +189,8 @@ class WebApiContext implements ApiClientAwareContext
         }
 
         $this->sendRequest();
+
+        return $this->response;
     }
 
     /**

--- a/src/Context/WebApiContextVoter.php
+++ b/src/Context/WebApiContextVoter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Behat\WebApiExtension\Context;
+
+use Sanpi\Behatch\HttpCall\ContextSupportedVoter;
+use Sanpi\Behatch\HttpCall\FilterableHttpCallResult;
+use Sanpi\Behatch\HttpCall\HttpCallResult;
+
+class WebApiContextVoter implements ContextSupportedVoter, FilterableHttpCallResult
+{
+    public function vote(HttpCallResult $httpCallResult)
+    {
+        return $httpCallResult->getValue() instanceof \GuzzleHttp\Message\Response;
+    }
+
+    public function filter(HttpCallResult $httpCallResult)
+    {
+        return $httpCallResult->getValue()->getBody();
+    }
+}

--- a/src/ServiceContainer/WebApiExtension.php
+++ b/src/ServiceContainer/WebApiExtension.php
@@ -64,6 +64,10 @@ class WebApiExtension implements ExtensionInterface
     {
         $this->loadClient($container, $config);
         $this->loadContextInitializer($container, $config);
+
+        if (class_exists('Sanpi\Behatch\Context\JsonContext')) {
+            $this->loadHttpCallVoter($container);
+        }
     }
 
     private function loadClient(ContainerBuilder $container, $config)
@@ -80,6 +84,13 @@ class WebApiExtension implements ExtensionInterface
         ));
         $definition->addTag(ContextExtension::INITIALIZER_TAG);
         $container->setDefinition('web_api.context_initializer', $definition);
+    }
+
+    private function loadHttpCallVoter(ContainerBuilder $container)
+    {
+        $definition = new Definition('Behat\WebApiExtension\Context\WebApiContextVoter');
+        $definition->addTag('behatch.context_voter');
+        $container->setDefinition('web_api.http_call.context_voter', $definition);
     }
 
     /**


### PR DESCRIPTION
Since this commit:
https://github.com/sanpii/behatch-contexts/commit/54088f29dc2d49be3211bd98410109648c3363c3

JsonContext from Behatch is no longer couple to mink.

So we can use it with WebApiExtension !

Here it is the code to make it working.
