### PR TITLE
Use ClientInterface instead of specific implementation

### DIFF
--- a/features/context.feature
+++ b/features/context.feature
@@ -9,13 +9,13 @@ Feature: client aware context
       <?php
 
       use Behat\WebApiExtension\Context\ApiClientAwareContext;
-      use GuzzleHttp\Client;
+      use GuzzleHttp\ClientInterface;
 
       class FeatureContext implements ApiClientAwareContext
       {
           private $client;
 
-          public function setClient(Client $client)
+          public function setClient(ClientInterface $client)
           {
               $this->client = $client;
           }

--- a/src/Context/ApiClientAwareContext.php
+++ b/src/Context/ApiClientAwareContext.php
@@ -11,7 +11,7 @@
 namespace Behat\WebApiExtension\Context;
 
 use Behat\Behat\Context\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 
 /**
  * Guzzle Client-aware interface for contexts.
@@ -29,5 +29,5 @@ interface ApiClientAwareContext extends Context
      *
      * @return void
      */
-    public function setClient(Client $client);
+    public function setClient(ClientInterface $client);
 }

--- a/src/Context/Initializer/ApiClientAwareInitializer.php
+++ b/src/Context/Initializer/ApiClientAwareInitializer.php
@@ -13,7 +13,7 @@ namespace Behat\WebApiExtension\Context\Initializer;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Initializer\ContextInitializer;
 use Behat\WebApiExtension\Context\ApiClientAwareContext;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 
 /**
  * Guzzle-aware contexts initializer.
@@ -25,16 +25,16 @@ use GuzzleHttp\Client;
 class ApiClientAwareInitializer implements ContextInitializer
 {
     /**
-     * @var Client
+     * @var ClientInterface
      */
     private $client;
 
     /**
      * Initializes initializer.
      *
-     * @param Client $client
+     * @param ClientInterface $client
      */
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->client = $client;
     }

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -12,7 +12,7 @@ namespace Behat\WebApiExtension\Context;
 
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use PHPUnit_Framework_Assert as Assertions;
 
@@ -29,7 +29,7 @@ class WebApiContext implements ApiClientAwareContext
     private $authorization;
 
     /**
-     * @var Client
+     * @var ClientInterface
      */
     private $client;
 
@@ -53,7 +53,7 @@ class WebApiContext implements ApiClientAwareContext
     /**
      * {@inheritdoc}
      */
-    public function setClient(Client $client)
+    public function setClient(ClientInterface $client)
     {
         $this->client = $client;
     }


### PR DESCRIPTION
Code should rely on interface instead of specific implementations. This commit provide ability to replace `GuzzleHttp\Client` class implementation to different one (wrapped for example).

For example in case of extensions, which add context for matching responses of API, it is very useful to just wrap `GuzzleHttp\Client` class and replace it in container.
