### PR TITLE
Make the response payload accessible for derived classes.

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -398,6 +398,13 @@ class WebApiContext implements ApiClientAwareContext
         return $this->response;
     }
 
+    /**
+     * @Then the ":arg1" header is set
+     */
+    public function theHeaderIsSet($headerName)
+    {
+        Assertions::assertTrue(array_key_exists($headerName, $this->response->getHeaders()));
+    }
 
      /**
      * Return the response payload from the current response.

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -433,7 +433,7 @@ class WebApiContext implements ApiClientAwareContext
                         break;
                 }
 
-                throw new Exception($message);
+                throw new \Exception($message);
             }
 
             $this->responsePayload = $json;

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -48,6 +48,11 @@ class WebApiContext implements ApiClientAwareContext
      */
     private $response;
 
+    /**
+     * The decoded response object.
+     */
+    private $responsePayload;
+
     private $placeHolders = array();
 
     /**
@@ -378,5 +383,62 @@ class WebApiContext implements ApiClientAwareContext
         }
 
         return $this->client;
+    }
+
+    /*
+     * Checks the response exists and returns it.
+     *
+     * @return Guzzle\Http\Message\Response
+     */
+    protected function getResponse()
+    {
+        if (! $this->response) {
+            throw new Exception("You must first make a request to check a response.");
+        }
+        return $this->response;
+    }
+
+
+     /**
+     * Return the response payload from the current response.
+     *
+     * @return  mixed
+     */
+    protected function getResponsePayload()
+    {
+        if (! $this->responsePayload) {
+            $json = json_decode($this->getResponse()->getBody(true));
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $message = 'Failed to decode JSON body ';
+
+                switch (json_last_error()) {
+                    case JSON_ERROR_DEPTH:
+                        $message .= '(Maximum stack depth exceeded).';
+                        break;
+                    case JSON_ERROR_STATE_MISMATCH:
+                        $message .= '(Underflow or the modes mismatch).';
+                        break;
+                    case JSON_ERROR_CTRL_CHAR:
+                        $message .= '(Unexpected control character found).';
+                        break;
+                    case JSON_ERROR_SYNTAX:
+                        $message .= '(Syntax error, malformed JSON).';
+                        break;
+                    case JSON_ERROR_UTF8:
+                        $message .= '(Malformed UTF-8 characters, possibly incorrectly encoded).';
+                        break;
+                    default:
+                        $message .= '(Unknown error).';
+                        break;
+                }
+
+                throw new Exception($message);
+            }
+
+            $this->responsePayload = $json;
+        }
+
+        return $this->responsePayload;
     }
 }


### PR DESCRIPTION
This allows a FeatureContext that derives from WebApiContext to add it's own assertions against the payload
