### PR TITLE
Upgrade to Guzzle v6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4",
         "behat/behat": "~3.0",
-        "guzzlehttp/guzzle": "4.*",
+        "guzzlehttp/guzzle": "6.*",
         "phpunit/phpunit": "~4.0"
     },
 

--- a/src/ServiceContainer/WebApiExtension.php
+++ b/src/ServiceContainer/WebApiExtension.php
@@ -68,7 +68,7 @@ class WebApiExtension implements ExtensionInterface
 
     private function loadClient(ContainerBuilder $container, $config)
     {
-        $definition = new Definition('GuzzleHttp\Client', array($config));
+        $definition = new Definition('GuzzleHttp\Client', array(array('base_uri' => $config['base_url'])));
         $container->setDefinition(self::CLIENT_ID, $definition);
     }
 


### PR DESCRIPTION
- Upgrade to Guzzle v6.
- Add public getters for Client and Response so custom steps can be created.
- Add assertion for checking JSON without supplying the body.

Shouldn't be any BC breaks directly relating to this package, BUT there will be a BC break if people are using Guzzle v4 elsewhere in their project, without a specifically defined dependency on guzzlehttp/guzzle:~4.0

Because of this, should this be a major version change (eg. 2.0)?

Relates to #28 