### PR TITLE
Response getter for WebApiExtension

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -379,4 +379,9 @@ class WebApiContext implements ApiClientAwareContext
 
         return $this->client;
     }
+    
+    public function getResponse()
+    {
+        return $this->response;
+    }     
 }


### PR DESCRIPTION
In order to add more step definitions, by extending the WebApiContext class, we need access to the response object. By default, the response property is defined with "private" visibility. We either need a getter or the visibility to be changed to protected. To keep the consistency, lets add a getter method.
