### PR TITLE
Do not require phpunit on production

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "require": {
         "php": ">=5.4",
         "behat/behat": "~3.0",
-        "guzzlehttp/guzzle": "4 - 5",
-        "phpunit/phpunit": "~4.0"
+        "guzzlehttp/guzzle": "4 - 5"
     },
 
     "require-dev": {
         "symfony/process": "~2.1",
-        "silex/silex": "~1"
+        "silex/silex": "~1",
+        "phpunit/phpunit": "~4.0"
     },
 
     "autoload": {


### PR DESCRIPTION
PHPUnit is for your tests.

Lot of projects may not need it because of not using phpunit or use global version.