### PR TITLE
Assert response against only defined keys.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.idea
+.DS_Store
 composer.lock
 vendor

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "behat/web-api-extension",
+    "name": "behat/extensible-web-api-extension",
     "type": "behat-extension",
     "description": "Web API extension for Behat",
     "keywords": ["api", "test"],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,10 @@
     "name": "behat/extensible-web-api-extension",
     "type": "behat-extension",
     "description": "Web API extension for Behat",
-    "keywords": ["api", "test"],
+    "keywords": [
+        "api",
+        "test"
+    ],
     "homepage": "http://extensions.behat.org",
     "license": "MIT",
     "authors": [
@@ -15,25 +18,21 @@
             "homepage": "https://github.com/Behat/WebApiExtension/graphs/contributors"
         }
     ],
-
     "require": {
         "php": ">=5.4",
         "behat/behat": "~3.0",
         "guzzlehttp/guzzle": "4 - 5",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "4 - 5"
     },
-
     "require-dev": {
         "symfony/process": "~2.1",
         "silex/silex": "~1"
     },
-
     "autoload": {
         "psr-4": {
             "Behat\\WebApiExtension\\": "src/"
         }
     },
-
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -273,6 +273,42 @@ class WebApiContext implements ApiClientAwareContext
     }
 
     /**
+     * Checks that JSON response key equals the value specified.
+     *
+     * Do not check that the response body /only/ contains the JSON from PyString,
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @Then /^(?:the )?response key "([^"]*)" should equal "([^"]*)"$/
+     */
+    public function theResponseKeyShouldEqual($key, $value)
+    {
+        $actual = $this->response->json();
+
+        Assertions::assertArrayHasKey($key, $actual);
+        Assertions::assertEquals($value, $actual[$key]);
+    }
+
+    /**
+     * Checks that JSON response key matches the value specified.
+     *
+     * Do not check that the response body /only/ contains the JSON from PyString,
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @Then /^(?:the )?response key "([^"]*)" should match "([^"]*)"$/
+     */
+    public function theResponseKeyShouldMatch($key, $value)
+    {
+        $actual = $this->response->json();
+
+        Assertions::assertArrayHasKey($key, $actual);
+        Assertions::assertRegExp($value, $actual[$key]);
+    }
+
+    /**
      * Prints last response body.
      *
      * @Then print response

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -124,7 +124,7 @@ class WebApiContext implements ApiClientAwareContext
         }
 
         $bodyOption = array(
-          'body' => json_encode($fields),
+            'body' => json_encode($fields),
         );
         $this->request = $this->getClient()->createRequest($method, $url, $bodyOption);
         if (!empty($this->headers)) {
@@ -245,67 +245,15 @@ class WebApiContext implements ApiClientAwareContext
 
         if (null === $etalon) {
             throw new \RuntimeException(
-              "Can not convert etalon to json:\n" . $this->replacePlaceHolder($jsonString->getRaw())
+                "Can not convert etalon to json:\n" . $this->replacePlaceHolder($jsonString->getRaw())
             );
         }
 
         Assertions::assertGreaterThanOrEqual(count($etalon), count($actual));
-        $this->assertEtalonKeyValuesEqualsActual($etalon, $actual);
-    }
-
-    /**
-     * Asserts that *only* the keys defined in etalon exist and are equal to the values defined in actual.
-     *
-     * @param array $etalon
-     * @param array $actual
-     */
-    private function assertEtalonKeyValuesEqualsActual(array $etalon, array $actual)
-    {
         foreach ($etalon as $key => $needle) {
-            if(is_array($needle)) {
-                $this->assertEtalonKeyValuesEqualsActual($etalon[$key], $actual[$key]);
-
-                continue;
-            }
             Assertions::assertArrayHasKey($key, $actual);
             Assertions::assertEquals($etalon[$key], $actual[$key]);
         }
-    }
-
-    /**
-     * Checks that JSON response key equals the value specified.
-     *
-     * Do not check that the response body /only/ contains the JSON from PyString,
-     *
-     * @param string $key
-     * @param string $value
-     *
-     * @Then /^(?:the )?response key "([^"]*)" should equal "([^"]*)"$/
-     */
-    public function theResponseKeyShouldEqual($key, $value)
-    {
-        $actual = $this->response->json();
-
-        Assertions::assertArrayHasKey($key, $actual);
-        Assertions::assertEquals($value, $actual[$key]);
-    }
-
-    /**
-     * Checks that JSON response key matches the value specified.
-     *
-     * Do not check that the response body /only/ contains the JSON from PyString,
-     *
-     * @param string $key
-     * @param string $value
-     *
-     * @Then /^(?:the )?response key "([^"]*)" should match "([^"]*)"$/
-     */
-    public function theResponseKeyShouldMatch($key, $value)
-    {
-        $actual = $this->response->json();
-
-        Assertions::assertArrayHasKey($key, $actual);
-        Assertions::assertRegExp($value, $actual[$key]);
     }
 
     /**

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -263,7 +263,7 @@ class WebApiContext implements ApiClientAwareContext
     {
         foreach ($etalon as $key => $needle) {
             if(is_array($needle)) {
-                $this->assertEtalonKeyValuesEqualActual($etalon[$key], $actual[$key]);
+                $this->assertEtalonKeyValuesEqualsActual($etalon[$key], $actual[$key]);
 
                 continue;
             }

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -431,4 +431,20 @@ class WebApiContext implements ApiClientAwareContext
 
         return $this->client;
     }
+
+    /**
+     * @return \GuzzleHttp\Message\RequestInterface
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return \GuzzleHttp\Message\ResponseInterface
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
 }

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -250,7 +250,23 @@ class WebApiContext implements ApiClientAwareContext
         }
 
         Assertions::assertGreaterThanOrEqual(count($etalon), count($actual));
+        $this->assertEtalonKeyValuesEqualsActual($etalon, $actual);
+    }
+
+    /**
+     * Asserts that *only* the keys defined in etalon exist and are equal to the values defined in actual.
+     *
+     * @param array $etalon
+     * @param array $actual
+     */
+    private function assertEtalonKeyValuesEqualsActual(array $etalon, array $actual)
+    {
         foreach ($etalon as $key => $needle) {
+            if(is_array($needle)) {
+                $this->assertEtalonKeyValuesEqualActual($etalon[$key], $actual[$key]);
+
+                continue;
+            }
             Assertions::assertArrayHasKey($key, $actual);
             Assertions::assertEquals($etalon[$key], $actual[$key]);
         }


### PR DESCRIPTION
A Scenario like this, will now pass without having to define variable keys like `_id`.

Actual Response:

```
[{"email":"email1@test.com","status":"sent","_id":"ee65fa503c664301b9e92c69b8624e6c","reject_reason":null},{"email":"email2@test.com","status":"sent","_id":"d22f4aca0ab94f7f87b38cacfbd30544","reject_reason":null}]
```

Partial Feature:

```
    And the response should contain json:                                                          
      """
      [
          {
              "email": "email1@test.com",
              "status": "sent",
              "reject_reason": null
          },
          {
              "email": "email2@test.com",
              "status": "sent",
              "reject_reason": null
          }
      ]
      """
```
