### PR TITLE
Improved: Now you can pass * at theResponseShouldContainJson()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=5.4",
         "behat/behat": "~3.0",
         "guzzlehttp/guzzle": "4 - 5",
+        "intellectsoft-uk/assert": "*@dev",
         "phpunit/phpunit": "~4.0"
     },
 
@@ -27,6 +28,11 @@
         "symfony/process": "~2.1",
         "silex/silex": "~1"
     },
+
+    "repositories": [{
+        "type": "vcs",
+        "url": "git@github.com:intellectsoft-uk/assert.git"
+    }],
 
     "autoload": {
         "psr-4": {

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -27,29 +27,29 @@ class WebApiContext implements ApiClientAwareContext
     /**
      * @var string
      */
-    private $authorization;
+    protected $authorization;
 
     /**
      * @var ClientInterface
      */
-    private $client;
+    protected $client;
 
     /**
      * @var array
      */
-    private $headers = array();
+    protected $headers = array();
 
     /**
      * @var \GuzzleHttp\Message\RequestInterface
      */
-    private $request;
+    protected $request;
 
     /**
      * @var \GuzzleHttp\Message\ResponseInterface
      */
-    private $response;
+    protected $response;
 
-    private $placeHolders = array();
+    protected $placeHolders = array();
 
     /**
      * {@inheritdoc}
@@ -273,7 +273,7 @@ class WebApiContext implements ApiClientAwareContext
      *
      * @return string
      */
-    private function prepareUrl($url)
+    protected function prepareUrl($url)
     {
         return ltrim($this->replacePlaceHolder($url), '/');
     }
@@ -349,7 +349,7 @@ class WebApiContext implements ApiClientAwareContext
         }
     }
 
-    private function sendRequest()
+    protected function sendRequest()
     {
         try {
             $this->response = $this->getClient()->send($this->request);
@@ -362,7 +362,7 @@ class WebApiContext implements ApiClientAwareContext
         }
     }
 
-    private function getClient()
+    protected function getClient()
     {
         if (null === $this->client) {
             throw new \RuntimeException('Client has not been set in WebApiContext');

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -15,6 +15,7 @@ use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use PHPUnit_Framework_Assert as Assertions;
+use Isdev\Assert\Assertion as JsonAssert;
 
 /**
  * Provides web API description definitions.
@@ -124,7 +125,7 @@ class WebApiContext implements ApiClientAwareContext
         }
 
         $bodyOption = array(
-          'body' => json_encode($fields),
+            'body' => json_encode($fields),
         );
         $this->request = $this->getClient()->createRequest($method, $url, $bodyOption);
         if (!empty($this->headers)) {
@@ -240,20 +241,10 @@ class WebApiContext implements ApiClientAwareContext
      */
     public function theResponseShouldContainJson(PyStringNode $jsonString)
     {
-        $etalon = json_decode($this->replacePlaceHolder($jsonString->getRaw()), true);
-        $actual = $this->response->json();
+        $etalon = $this->replacePlaceHolder($jsonString->getRaw());
+        $actual = $this->response->getBody();
 
-        if (null === $etalon) {
-            throw new \RuntimeException(
-              "Can not convert etalon to json:\n" . $this->replacePlaceHolder($jsonString->getRaw())
-            );
-        }
-
-        Assertions::assertGreaterThanOrEqual(count($etalon), count($actual));
-        foreach ($etalon as $key => $needle) {
-            Assertions::assertArrayHasKey($key, $actual);
-            Assertions::assertEquals($etalon[$key], $actual[$key]);
-        }
+        JsonAssert::jsonStringMatchJsonString($etalon, $actual);
     }
 
     /**


### PR DESCRIPTION
Now you can write scenarios like this (with wildcards at etalon json):

```
Scenario: I can get the list via API
        When I set header "Accept" with value "application/json"
         And I send a GET request to "/api/endpoint"
        Then the response code should be 200
         And response should contain json:
            """
                [{
                    "id": "*",
                    "updated_at":"*",
                    "downloaded_at":"*",
                    "_links": "*"
                }]
            """
```
