### PR TITLE
PHPUnit dependency removal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.4",
         "behat/behat": "~3.0",
         "guzzlehttp/guzzle": "4 - 5",
-        "phpunit/phpunit": "4 - 5"
+        "beberlei/assert": "^2.4"
     },
 
     "require-dev": {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -119,7 +119,7 @@ class FeatureContext implements SnippetAcceptingContext
      */
     public function theOutputShouldContain(PyStringNode $text)
     {
-        PHPUnit_Framework_Assert::assertContains($this->getExpectedOutput($text), $this->getOutput());
+        \Assert\Assertion::contains($this->getOutput(), $this->getExpectedOutput($text));
     }
 
     private function getExpectedOutput(PyStringNode $expectedText)
@@ -162,13 +162,13 @@ class FeatureContext implements SnippetAcceptingContext
                 echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            PHPUnit_Framework_Assert::assertNotEquals(0, $this->getExitCode());
+            \Assert\Assertion::notSame($this->getExitCode(), 0);
         } else {
             if (0 !== $this->getExitCode()) {
                 echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            PHPUnit_Framework_Assert::assertEquals(0, $this->getExitCode());
+            \Assert\Assertion::same($this->getExitCode(), 0);
         }
     }
 

--- a/features/context.feature
+++ b/features/context.feature
@@ -8,6 +8,7 @@ Feature: client aware context
       """
       <?php
 
+      use Assert\Assertion;
       use Behat\WebApiExtension\Context\ApiClientAwareContext;
       use GuzzleHttp\ClientInterface;
 
@@ -24,7 +25,7 @@ Feature: client aware context
            * @Then /^the client should be set$/
            */
           public function theClientShouldBeSet() {
-              PHPUnit_Framework_Assert::assertInstanceOf('GuzzleHttp\Client', $this->client);
+              Assertion::isInstanceOf($this->client, ClientInterface::class);
           }
       }
       """

--- a/features/context.feature
+++ b/features/context.feature
@@ -25,7 +25,7 @@ Feature: client aware context
            * @Then /^the client should be set$/
            */
           public function theClientShouldBeSet() {
-              Assertion::isInstanceOf($this->client, ClientInterface::class);
+              Assertion::isInstanceOf($this->client, 'GuzzleHttp\ClientInterface');
           }
       }
       """


### PR DESCRIPTION
Addresses issue #37 by surgically replacing instances of \PHPUnit_Framework_Assert for the much lighter \Assert\Assertion class from the [beberlei/assert](https://github.com/beberlei/assert) library.
