### PR TITLE
Expose the response object

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -387,6 +387,16 @@ class WebApiContext implements ApiClientAwareContext
         }
     }
 
+    /**
+     * Returns the response object
+     *
+     * @return \GuzzleHttp\Message\ResponseInterface|ResponseInterface
+     */
+    protected function getResponse()
+    {
+        return $this->response;
+    }
+
     private function sendRequest()
     {
         try {


### PR DESCRIPTION
This PR adds a `getResponse()` method to the `Behat\WebApiExtension\Context\WebApiContext` class so that classes extending this can access the response instance. Will solve #45.

I have a context class that adds some `@Given/@When/@Then` that uses the response instance that uses the code added in this PR as well.