### PR TITLE
Add default options for guzzle client

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -380,7 +380,7 @@ class WebApiContext implements ApiClientAwareContext
      *
      * @param string $headerName
      */
-    protected function removeHeader($headerName)
+    public function removeHeader($headerName)
     {
         if (array_key_exists($headerName, $this->headers)) {
             unset($this->headers[$headerName]);

--- a/src/ServiceContainer/WebApiExtension.php
+++ b/src/ServiceContainer/WebApiExtension.php
@@ -54,6 +54,10 @@ class WebApiExtension implements ExtensionInterface
                 ->scalarNode('base_url')
                     ->defaultValue('http://localhost')
                     ->end()
+                ->arrayNode('defaults')
+                   ->useAttributeAsKey('key')
+                   ->prototype('variable')->end()
+                   ->end()
                 ->end()
             ->end();
     }


### PR DESCRIPTION
Hi.

My use case is this: I need allow unverified https site in tests cause the environment doesn't have certificate.

I tried use key 'defaults' in my behat.yml but I saw this error:

>   [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]  
  Unrecognized option "defaults" under "testwork.web_api" 

Here is my behat.yml

> default:
>   autoload:    '': %paths.base%/tests/behat/bootstrap
>   suites:
>     default:
>       paths:
>         - %paths.base%/tests/behat/features
>       contexts:
>         - Behat\WebApiExtension\Context\WebApiContext:
>   extensions:
>     Behat\WebApiExtension\ServiceContainer\WebApiExtension:
>       base_url: 'https://rest-testing.me/'
>       defaults:
>         verify: false
>         ssl.certificate_authority: false


I attach a patch adding defaults key.

Can you review this, please? Thanks!