### PR TITLE
Add a method for getting response as string

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -305,6 +305,18 @@ class WebApiContext implements ApiClientAwareContext
     }
 
     /**
+     * Returns the response as a string.
+     *
+     * @return string
+     */
+    public function getResponseAsString()
+    {
+        if ($this->response) {
+            return (string) $this->response->getBody();
+        }
+    }
+
+    /**
      * Prepare URL by replacing placeholders and trimming slashes.
      *
      * @param string $url


### PR DESCRIPTION
In order to make this class extendable, we need to have access to the response object. Considering the compatibility issues (guzzle 5 vs 6), the simplest approach seems to be returning the response as a string.